### PR TITLE
Image dev

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,7 +26,14 @@ function App() {
         <Navbar></Navbar>
         <Routes>
           <Route path="/landingpage" element={<LandingPage />} />
-          <Route path="/" element={<Home />} />
+          <Route
+            path="/"
+            element={
+              <ProtectedRoute>
+                <Home />
+              </ProtectedRoute>
+            }
+          />
           <Route
             path="/home"
             element={
@@ -59,7 +66,7 @@ function App() {
               </ProtectedRoute>
             }
           />
-           <Route
+          <Route
             path="/create"
             element={
               <ProtectedRoute>

--- a/src/hooks/useImage.jsx
+++ b/src/hooks/useImage.jsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { useState, useEffect } from "react";
+import useFetch from "./useFetch";
+function useImage() {
+  const { handleData, data, loading, response, error } = useFetch();
+  const [imageUrl, setImageUrl] = useState("");
+
+  //When the post has been made we expose the url given back from the api request.
+  //We can then use the url and save it as the images' url in the database.
+  useEffect(() => {
+    if (data !== null) {
+      setImageUrl(data.data.url);
+    }
+  }, [data]);
+
+  //Transform file to formdata and set it up as the imgbb-endpoint needs to have it.
+  function createFormData(file) {
+    const formData = new FormData();
+    formData.append("image", file);
+    return formData;
+  }
+
+  //Save image in online storage.
+  async function saveImage(file) {
+    const formData = createFormData(file);
+    await handleData(
+      "https://api.imgbb.com/1/upload?key=97f81df3cc81a176ff696a8be56250aa",
+      "POST",
+      formData
+    );
+  }
+
+  return { saveImage, imageUrl, loading, response, error };
+}
+
+export default useImage;


### PR DESCRIPTION
Setup custom hook "useImage" that exposes a method called saveImage, which will store the file sent along as parameter in online storage (imgbb).
The create page will be able to use this method to save each image to items that the user creates when creating games. It will return an url that we should store in the database so that we can display it on the game page.

The saveImage-method uses another custom hook called useFetch which is already in use. In order to be able to use useFetch and the handleData-method for external use too, I needed to make adjustment to check the url provided to the handleData-method so we don't send authorization header for external calls.

Unrelated I added "/" as protected route so that unauthenticated users can't reach it but will be redirected to landing page.